### PR TITLE
chore: upgrade golangci-lint to v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      GOLANGCI_LINT_VERSION: v2.2.1
+      GOLANGCI_LINT_VERSION: v2.3.0
       CGO_ENABLED: 0
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: stable
-      GOLANGCI_LINT_VERSION: v1.62.0
+      GOLANGCI_LINT_VERSION: v2.2.1
       CGO_ENABLED: 0
 
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,10 +92,7 @@ issues:
 formatters:
   enable:
     - gci
-    - gofmt
     - gofumpt
-    - goimports
-    - golines
 
   settings:
     gofumpt:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,12 +98,5 @@ formatters:
     gofumpt:
       extra-rules: true
 
-    golines:
-      max-len: 200
-      tab-len: 4
-      shorten-comments: true
-      reformat-tags: false
-      chain-split-dots: false
-
 output:
   show-stats: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,65 +1,65 @@
+version: "2"
+
 run:
   timeout: 10m
 
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  gocyclo:
-    min-complexity: 15
-  goconst:
-    min-len: 5
-    min-occurrences: 3
-  misspell:
-    locale: US
-  funlen:
-    lines: -1
-    statements: 50
-  godox:
-    keywords:
-      - FIXME
-  gofumpt:
-    extra-rules: true
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "github.com/instana/testify"
-            desc: not allowed
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib errors package
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-      - performance
-    disabled-checks:
-      - sloppyReassign
-      - rangeValCopy
-      - octalLiteral
-      - paramTypeCombine # already handle by gofumpt.extra-rules
-      - unnamedResult
-      - hugeParam
-  tagliatelle:
-    case:
-      rules:
-        json: pascal
-  gosec:
-    excludes:
-      - G304
-      - G306
-
 linters:
-  enable-all: true
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    gocyclo:
+      min-complexity: 15
+    goconst:
+      min-len: 5
+      min-occurrences: 3
+    misspell:
+      locale: US
+    funlen:
+      lines: -1
+      statements: 50
+    godox:
+      keywords:
+        - FIXME
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "github.com/instana/testify"
+              desc: not allowed
+            - pkg: "github.com/pkg/errors"
+              desc: Should be replaced by standard lib errors package
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+      disabled-checks:
+        - sloppyReassign
+        - rangeValCopy
+        - octalLiteral
+        - paramTypeCombine # already handle by gofumpt.extra-rules
+        - unnamedResult
+        - hugeParam
+    tagliatelle:
+      case:
+        rules:
+          json: pascal
+    gosec:
+      excludes:
+        - G304
+        - G306
+
+  default: all
   disable:
-    - exportloopref # deprecated
     - sqlclosecheck # not relevant (SQL)
     - rowserrcheck # not relevant (SQL)
     - cyclop # duplicate of gocyclo
     - lll
     - dupl
     - wsl
+    - wsl_v5
     - nlreturn
     - mnd
     - err113
@@ -78,17 +78,35 @@ linters:
     - errchkjson
     - contextcheck
 
+  exclusions:
+    warn-unused: true
+    rules:
+      - text: fmt.Sprintf can be replaced with string
+        linters:
+          - perfsprint
+
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude:
-    - 'fmt.Sprintf can be replaced with string'
-  exclude-rules:
-    - path: .*_test.go
-      linters:
-        - funlen
-        - noctx
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+
+  settings:
+    gofumpt:
+      extra-rules: true
+
+    golines:
+      max-len: 200
+      tab-len: 4
+      shorten-comments: true
+      reformat-tags: false
+      chain-split-dots: false
 
 output:
   show-stats: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: clean lint test build
 
 lint:
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1 run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0 run
 
 clean:
 	rm -rf cover.out

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: clean lint test build
 
 lint:
-	golangci-lint run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.1 run
 
 clean:
 	rm -rf cover.out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traefik/mocktail
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/mocktail.go
+++ b/mocktail.go
@@ -4,6 +4,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"go/format"
@@ -42,7 +43,9 @@ type InterfaceDesc struct {
 }
 
 func main() {
-	info, err := getModuleInfo(os.Getenv("MOCKTAIL_TEST_PATH"))
+	ctx := context.Background()
+
+	info, err := getModuleInfo(ctx, os.Getenv("MOCKTAIL_TEST_PATH"))
 	if err != nil {
 		log.Fatal("get module path", err)
 	}

--- a/mocktail_test.go
+++ b/mocktail_test.go
@@ -29,7 +29,7 @@ func TestMocktail(t *testing.T) {
 
 		t.Setenv("MOCKTAIL_TEST_PATH", filepath.Join(testRoot, entry.Name()))
 
-		output, err := exec.Command("go", "run", ".").CombinedOutput()
+		output, err := exec.CommandContext(t.Context(), "go", "run", ".").CombinedOutput()
 		t.Log(string(output))
 
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestMocktail(t *testing.T) {
 			continue
 		}
 
-		cmd := exec.Command("go", "test", "-v", "./...")
+		cmd := exec.CommandContext(t.Context(), "go", "test", "-v", "./...")
 		cmd.Dir = filepath.Join(testRoot, entry.Name())
 
 		output, err := cmd.CombinedOutput()
@@ -88,7 +88,7 @@ func TestMocktail_exported(t *testing.T) {
 
 		t.Setenv("MOCKTAIL_TEST_PATH", filepath.Join(testRoot, entry.Name()))
 
-		output, err := exec.Command("go", "run", ".", "-e").CombinedOutput()
+		output, err := exec.CommandContext(t.Context(), "go", "run", ".", "-e").CombinedOutput()
 		t.Log(string(output))
 
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestMocktail_exported(t *testing.T) {
 			continue
 		}
 
-		cmd := exec.Command("go", "test", "-v", "./...")
+		cmd := exec.CommandContext(t.Context(), "go", "test", "-v", "./...")
 		cmd.Dir = filepath.Join(testRoot, entry.Name())
 
 		output, err := cmd.CombinedOutput()

--- a/mod.go
+++ b/mod.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,9 +17,9 @@ type modInfo struct {
 	Main      bool   `json:"Main"`
 }
 
-func getModuleInfo(dir string) (modInfo, error) {
+func getModuleInfo(ctx context.Context, dir string) (modInfo, error) {
 	// https://github.com/golang/go/issues/44753#issuecomment-790089020
-	cmd := exec.Command("go", "list", "-m", "-json")
+	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-json")
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/syrup.go
+++ b/syrup.go
@@ -98,6 +98,36 @@ type Syrup struct {
 	Signature     *types.Signature
 }
 
+// Call generates mock.Call wrapper.
+func (s Syrup) Call(writer io.Writer, methods []*types.Func) error {
+	err := s.callBase(writer)
+	if err != nil {
+		return err
+	}
+
+	err = s.typedReturns(writer)
+	if err != nil {
+		return err
+	}
+
+	err = s.returnsFn(writer)
+	if err != nil {
+		return err
+	}
+
+	err = s.typedRun(writer)
+	if err != nil {
+		return err
+	}
+
+	err = s.callMethodsOn(writer, methods)
+	if err != nil {
+		return err
+	}
+
+	return s.callMethodOnRaw(writer, methods)
+}
+
 // MockMethod generates method mocks.
 func (s Syrup) MockMethod(writer io.Writer) error {
 	err := s.mockedMethod(writer)
@@ -310,36 +340,6 @@ func (s Syrup) methodOnRaw(writer io.Writer) error {
 	w.Println()
 
 	return w.Err()
-}
-
-// Call generates mock.Call wrapper.
-func (s Syrup) Call(writer io.Writer, methods []*types.Func) error {
-	err := s.callBase(writer)
-	if err != nil {
-		return err
-	}
-
-	err = s.typedReturns(writer)
-	if err != nil {
-		return err
-	}
-
-	err = s.returnsFn(writer)
-	if err != nil {
-		return err
-	}
-
-	err = s.typedRun(writer)
-	if err != nil {
-		return err
-	}
-
-	err = s.callMethodsOn(writer, methods)
-	if err != nil {
-		return err
-	}
-
-	return s.callMethodOnRaw(writer, methods)
 }
 
 func (s Syrup) callBase(writer io.Writer) error {


### PR DESCRIPTION
Following the release of [v2.3.0](https://github.com/golangci/golangci-lint/releases/tag/v2.3.0), and most importantly of [v2.0.0](https://github.com/golangci/golangci-lint/releases/tag/v2.0.0), this PR updates the linter to the current latest version of golangci-lint.

Update to go1.24 btw